### PR TITLE
Fix tests to use the README.md (in caps) file

### DIFF
--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ test.serial('generates expected files', async () => {
   await pify(generator.run.bind(generator))()
 
   assert.file([
-    'readme.md'
+    'README.md'
   ])
 })
 


### PR DESCRIPTION
Lets test if this was the problem in #4 