### PR TITLE
Add suggestion for licensee's full name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -76,7 +76,7 @@ export default class StandardReadmeGenerator extends Generator {
         message: 'What is the username of the main maintainer?',
         type: 'input',
         default: async () => {
-          let defaultMaintainer = usernameSync()
+          let defaultMaintainer = usernameSync() ?? ''
           try {
             defaultMaintainer = execSync('git config user.name', { encoding: 'utf8' }).trim()
           } catch (_) {}

--- a/app/index.js
+++ b/app/index.js
@@ -100,26 +100,33 @@ export default class StandardReadmeGenerator extends Generator {
         return val.length > 0 ? true : 'You have to provide a license'
       },
       when: x => !x.mit
-    }, {
-      name: 'licensee',
-      message: 'Who is the License holder (probably your name)?',
-      type: 'input',
-      default: await fullName(),
-      validate: x => x.length !== 0 ? true : 'You must attribute the license to someone.'
-    }, {
-      name: 'year',
-      message: 'Use the current year?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'diffYear',
-      message: 'What years would you like to specify?',
-      type: 'input',
-      validate: (val) => {
-        return val
-      },
-      when: x => !x.year
     }])
+
+    // Separate prompting into two calls to use previous answers as defaults for
+    // newer questions.
+    this.props = {
+      ...this.props,
+      ...(await this.prompt([{
+        name: 'licensee',
+        message: 'Who is the License holder (probably your name)?',
+        type: 'input',
+        default: await fullName() ?? this.props.maintainers,
+        validate: x => x.length !== 0 ? true : 'You must attribute the license to someone.'
+      }, {
+        name: 'year',
+        message: 'Use the current year?',
+        type: 'confirm',
+        default: true
+      }, {
+        name: 'diffYear',
+        message: 'What years would you like to specify?',
+        type: 'input',
+        validate: (val) => {
+          return val
+        },
+        when: x => !x.year
+      }]))
+    }
   }
 
   writing () {

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 import Generator from 'yeoman-generator'
 import _s from 'underscore.string'
+import fullName from 'fullname'
 
 const domainRegex = /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/
 
@@ -103,6 +104,7 @@ export default class StandardReadmeGenerator extends Generator {
       name: 'licensee',
       message: 'Who is the License holder (probably your name)?',
       type: 'input',
+      default: await fullName(),
       validate: x => x.length !== 0 ? true : 'You must attribute the license to someone.'
     }, {
       name: 'year',

--- a/app/index.js
+++ b/app/index.js
@@ -1,116 +1,119 @@
 import Generator from 'yeoman-generator'
 import _s from 'underscore.string'
 import fullName from 'fullname'
+import { usernameSync } from 'username'
+import { execSync } from 'node:child_process'
 
 const domainRegex = /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/
 
 export default class StandardReadmeGenerator extends Generator {
-  async prompting () {
-    this.props = await this.prompt([{
-      name: 'moduleName',
-      message: 'What is the name of your module?',
-      default: this.appname.replace(/\s/g, '-'),
-      filter: x => _s.slugify(x)
-    }, {
-      name: 'description',
-      message: 'What is the description of this module?',
-      store: true,
-      validate: x => x.length > 0 ? true : 'You have to provide a module description'
-    }, {
-      name: 'banner',
-      message: 'Do have a banner image?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'bannerPath',
-      message: 'Where is the banner image? Ex: \'img/banner.png\'',
-      type: 'input',
-      when: (answers) => answers.banner
-    }, {
-      name: 'badge',
-      message: 'Do you want a standard-readme compliant badge?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'badges',
-      message: 'Do you want a TODO dropped where more badges should be?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'longDescription',
-      message: 'Do you want a TODO dropped where your long description should be?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'security',
-      message: 'Do you need a prioritized security section?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'background',
-      message: 'Do you need a background section?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'API',
-      message: 'Do you need an API section?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'maintainers',
-      message: 'What is the username of the main maintainer?',
-      type: 'input',
-      validate: (val) => {
-        return val.length > 0 ? true : 'You must name a maintainer.'
-      },
-      when: x => !x.mit
-    }, {
-      name: 'hostedGithub',
-      message: 'Is the project host on github.com?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'hostedDomain',
-      message: 'Where is the project hosted?',
-      type: 'input',
-      validate: (val) => {
-        return domainRegex.test(val) ? true : 'You must enter a domain where the project is hosted.'
-      },
-      when: x => !x.hostedGithub
-    }, {
-      name: 'contributingFile',
-      message: 'Do you have a CONTRIBUTING.md file?',
-      type: 'confirm',
-      default: false
-    }, {
-      name: 'prs',
-      message: 'Are PRs accepted?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'mit',
-      message: 'Is an MIT license OK?',
-      type: 'confirm',
-      default: true
-    }, {
-      name: 'license',
-      message: 'What is your license?',
-      type: 'input',
-      validate: (val) => {
-        return val.length > 0 ? true : 'You have to provide a license'
-      },
-      when: x => !x.mit
-    }])
+  constructor (...args) {
+    super(...args)
 
-    // Separate prompting into two calls to use previous answers as defaults for
-    // newer questions.
-    this.props = {
-      ...this.props,
-      ...(await this.prompt([{
+    this.props = {}
+    /** @type {import('yeoman-generator').PromptQuestions} */
+    this.promptQuestions = [
+      {
+        name: 'moduleName',
+        message: 'What is the name of your module?',
+        default: this.appname.replace(/\s/g, '-'),
+        filter: x => _s.slugify(x)
+      }, {
+        name: 'description',
+        message: 'What is the description of this module?',
+        store: true,
+        validate: x => x.length > 0 ? true : 'You have to provide a module description'
+      }, {
+        name: 'banner',
+        message: 'Do have a banner image?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'bannerPath',
+        message: 'Where is the banner image? Ex: \'img/banner.png\'',
+        type: 'input',
+        when: (answers) => answers.banner
+      }, {
+        name: 'badge',
+        message: 'Do you want a standard-readme compliant badge?',
+        type: 'confirm',
+        default: true
+      }, {
+        name: 'badges',
+        message: 'Do you want a TODO dropped where more badges should be?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'longDescription',
+        message: 'Do you want a TODO dropped where your long description should be?',
+        type: 'confirm',
+        default: true
+      }, {
+        name: 'security',
+        message: 'Do you need a prioritized security section?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'background',
+        message: 'Do you need a background section?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'API',
+        message: 'Do you need an API section?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'hostedDomain',
+        message: 'Where is the project hosted?',
+        type: 'input',
+        default: 'github.com',
+        validate: (val) => {
+          return domainRegex.test(val) ? true : 'You must enter a domain where the project is hosted.'
+        }
+      }, {
+        name: 'mainMaintainer',
+        message: 'What is the username of the main maintainer?',
+        type: 'input',
+        default: async () => {
+          let defaultMaintainer = usernameSync()
+          try {
+            defaultMaintainer = execSync('git config user.name', { encoding: 'utf8' }).trim()
+          } catch (_) {}
+
+          return defaultMaintainer
+        },
+        validate: (val) => val.length > 0 ? true : 'You must name a maintainer'
+      }, {
+        name: 'contributingFile',
+        message: 'Do you have a CONTRIBUTING.md file?',
+        type: 'confirm',
+        default: false
+      }, {
+        name: 'prs',
+        message: 'Are PRs accepted?',
+        type: 'confirm',
+        default: true
+      }, {
+        name: 'mit',
+        message: 'Is an MIT license OK?',
+        type: 'confirm',
+        default: true
+      }, {
+        name: 'license',
+        message: 'What is your license?',
+        type: 'input',
+        validate: (val) => {
+          return val.length > 0 ? true : 'You have to provide a license'
+        },
+        when: x => !x.mit
+      }, {
         name: 'licensee',
         message: 'Who is the License holder (probably your name)?',
         type: 'input',
-        default: await fullName() ?? this.props.maintainers,
+        default: async ({ mainMaintainer }) => {
+          return (await fullName()) ?? mainMaintainer
+        },
         validate: x => x.length !== 0 ? true : 'You must attribute the license to someone.'
       }, {
         name: 'year',
@@ -122,11 +125,15 @@ export default class StandardReadmeGenerator extends Generator {
         message: 'What years would you like to specify?',
         type: 'input',
         validate: (val) => {
-          return val
+          return val.length > 0 ? true : 'You must provide a year for the license'
         },
         when: x => !x.year
-      }]))
-    }
+      }
+    ]
+  }
+
+  async prompting () {
+    this.props = await this.prompt(this.promptQuestions)
   }
 
   writing () {

--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -16,7 +16,7 @@ TODO: Put more badges here.<% } %>
 <% } %>- [Install](#install)
 - [Usage](#usage)
 <% if (API) { %>- [API](#api)
-<% } %><% if (maintainers) { %>- [Maintainers](#maintainers)
+<% } %><% if (mainMaintainer) { %>- [Maintainers](#maintainers)
 <% } %>- [Contributing](#contributing)
 - [License](#license)
 
@@ -38,7 +38,7 @@ TODO: Put more badges here.<% } %>
 
 <% } %>## Maintainers
 
-[@<%= maintainers %>](https://<% if (hostedGithub) { %>github.com<% } %><% if (!hostedGithub && hostedDomain) { %><%= hostedDomain %><% } %>/<%= maintainers %>)
+[@<%= mainMaintainer %>](https://<%= hostedDomain %>/<%= mainMaintainer %>)
 
 ## Contributing
 

--- a/examples/api-readme.md
+++ b/examples/api-readme.md
@@ -10,6 +10,7 @@ TODO: Fill out this long description.
 
 - [Install](#install)
 - [Usage](#usage)
+- [API](#api)
 - [Maintainers](#maintainers)
 - [Contributing](#contributing)
 - [License](#license)
@@ -24,6 +25,8 @@ TODO: Fill out this long description.
 ```sh
 ```
 
+## API
+
 ## Maintainers
 
 [@RichardLitt](https://github.com/RichardLitt)
@@ -37,4 +40,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/background-readme.md
+++ b/examples/background-readme.md
@@ -8,11 +8,14 @@ TODO: Fill out this long description.
 
 ## Table of Contents
 
+- [Background](#background)
 - [Install](#install)
 - [Usage](#usage)
 - [Maintainers](#maintainers)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Background
 
 ## Install
 
@@ -37,4 +40,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/badges-readme.md
+++ b/examples/badges-readme.md
@@ -1,6 +1,7 @@
 # module-name
 
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+TODO: Put more badges here.
 
 description
 
@@ -37,4 +38,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/banner-readme.md
+++ b/examples/banner-readme.md
@@ -1,5 +1,7 @@
 # module-name
 
+![banner](test/banner.png)
+
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 description
@@ -37,4 +39,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/contributing-file-readme.md
+++ b/examples/contributing-file-readme.md
@@ -30,6 +30,8 @@ TODO: Fill out this long description.
 
 ## Contributing
 
+See [the contributing file](contributing.md)!
+
 PRs accepted.
 
 Small note: If editing the README, please conform to the
@@ -37,4 +39,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/default-readme.md
+++ b/examples/default-readme.md
@@ -1,8 +1,8 @@
-# temp
+# module-name
 
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
-test
+description
 
 TODO: Fill out this long description.
 

--- a/examples/different-year.md
+++ b/examples/different-year.md
@@ -1,8 +1,8 @@
-# temp
+# module-name
 
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
-test
+description
 
 TODO: Fill out this long description.
 

--- a/examples/maximal-readme.md
+++ b/examples/maximal-readme.md
@@ -5,7 +5,7 @@
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 TODO: Put more badges here.
 
-test
+description
 
 TODO: Fill out this long description.
 

--- a/examples/no-badge-readme.md
+++ b/examples/no-badge-readme.md
@@ -1,6 +1,5 @@
 # module-name
 
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 description
 
@@ -37,4 +36,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/no-long-description-readme.md
+++ b/examples/no-long-description-readme.md
@@ -4,8 +4,6 @@
 
 description
 
-TODO: Fill out this long description.
-
 ## Table of Contents
 
 - [Install](#install)
@@ -37,4 +35,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/prs-readme.md
+++ b/examples/prs-readme.md
@@ -30,11 +30,11 @@ TODO: Fill out this long description.
 
 ## Contributing
 
-PRs accepted.
+
 
 Small note: If editing the README, please conform to the
 [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/examples/security-readme.md
+++ b/examples/security-readme.md
@@ -8,11 +8,14 @@ TODO: Fill out this long description.
 
 ## Table of Contents
 
+- [Security](#security)
 - [Install](#install)
 - [Usage](#usage)
 - [Maintainers](#maintainers)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Security
 
 ## Install
 
@@ -37,4 +40,4 @@ Small note: If editing the README, please conform to the
 
 ## License
 
-CC BY-SA 4.0 © 2018 Richard McRichface
+MIT © 2018 Richard McRichface

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
+        "fullname": "^5.0.0",
         "underscore.string": "^3.3.6",
         "yeoman-environment": "^4.4.3",
         "yeoman-generator": "^7.5.1"
@@ -4615,6 +4616,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4756,6 +4769,26 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fullname": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fullname/-/fullname-5.0.0.tgz",
+      "integrity": "sha512-RVjGQY8ryXcWMrvjyXK4v9pK2kFyHOEqJz/JslPadc+HQMzqbSwX+y5Emvzg5I+TPNe8f5VqF5xQn72qUnP6Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "filter-obj": "^5.1.0",
+        "mem": "^5.1.0",
+        "p-any": "^4.0.0",
+        "passwd-user": "^4.0.0",
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/function-bind": {
@@ -6268,6 +6301,18 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6276,6 +6321,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mem": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
+      "integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
+      "license": "MIT",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^2.1.0",
+        "p-is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/mem-fs": {
@@ -6345,6 +6404,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mem/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/merge-stream": {
@@ -7222,6 +7290,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-any": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-4.0.0.tgz",
+      "integrity": "sha512-S/B50s+pAVe0wmEZHmBs/9yJXeZ5KhHzOsgKzt0hRdgkoR3DxW9ts46fcsWi/r3VnzsnkKS7q4uimze+zjdryw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-cancelable": "^3.0.0",
+        "p-some": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7280,6 +7391,77 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-6.0.0.tgz",
+      "integrity": "sha512-CJbQCKdfSX3fIh8/QKgS+9rjm7OBNUTmwWswAFQAhc8j1NR1dsEDETUEuVUtQHZpV+J03LqWBEwvu0g1Yn+TYg==",
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^4.0.0",
+        "p-cancelable": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some/node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7455,6 +7637,128 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/passwd-user": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-4.0.0.tgz",
+      "integrity": "sha512-Y0hVgYTHsWRkOF/lG2ciRChuD1kiQCGbmg9hQuyxRrszz2B9779U8nUa90NVJ089UTCFIcvfQ6zgmbXj/YoIYg==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/passwd-user/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/passwd-user/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/passwd-user/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/passwd-user/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/passwd-user/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/passwd-user/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/passwd-user/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/passwd-user/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/passwd-user/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "fullname": "^5.0.0",
         "underscore.string": "^3.3.6",
+        "username": "^7.0.0",
         "yeoman-environment": "^4.4.3",
         "yeoman-generator": "^7.5.1"
       },
@@ -6415,6 +6416,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9775,6 +9791,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/username": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/username/-/username-7.0.0.tgz",
+      "integrity": "sha512-MkXUkVGJzcTpIXo7vnIGokz+WzDqEuRUcHJzDm3ZPXFUUNwMmkf26Hz8HqN3ZhWZisWaP/c6Y3/ERBdUDGl9LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "memoize": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9555,9 +9555,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "fullname": "^5.0.0",
     "underscore.string": "^3.3.6",
+    "username": "^7.0.0",
     "yeoman-environment": "^4.4.3",
     "yeoman-generator": "^7.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "type": "module",
   "main": "app/index.js",
   "dependencies": {
+    "fullname": "^5.0.0",
     "underscore.string": "^3.3.6",
     "yeoman-environment": "^4.4.3",
     "yeoman-generator": "^7.5.1"

--- a/test.js
+++ b/test.js
@@ -112,7 +112,7 @@ describe('standard-readme:app', async () => {
       readFileSync(join(customTempDir, 'README.md')).toString(),
       readFileSync(join(exampleDir, 'default-readme.md')).toString()
         .replace('2018', new Date().getFullYear())
-        .replace('Richard McRichface', await fullName())
+        .replace('Richard McRichface', await fullName() ?? '')
     )
   })
 

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import fullName from 'fullname'
 import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -95,6 +96,23 @@ describe('standard-readme:app', async () => {
       readFileSync(join(customTempDir, 'README.md')).toString(),
       readFileSync(join(exampleDir, 'default-readme.md')).toString()
         .replace('2018', new Date().getFullYear())
+    )
+  })
+
+  test('generates README with suggested full name', async () => {
+    await result
+      .create(join(__dirname, './app'))
+      .withAnswers({
+        description: 'test',
+        maintainers: 'RichardLitt'
+      })
+      .run()
+
+    assert.strictEqual(
+      readFileSync(join(customTempDir, 'README.md')).toString(),
+      readFileSync(join(exampleDir, 'default-readme.md')).toString()
+        .replace('2018', new Date().getFullYear())
+        .replace('Richard McRichface', await fullName())
     )
   })
 

--- a/test.js
+++ b/test.js
@@ -4,8 +4,36 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { beforeEach, describe, test } from 'vitest'
 import helpers, { result } from 'yeoman-test'
+import Environment from 'yeoman-environment'
 
-describe('standard-readme:app', async () => {
+import StandardReadmeGenerator from './app'
+
+// Keeping default answers from generator synced with defaults used in tests.
+const generator = new StandardReadmeGenerator([], {
+  resolved: '',
+  namespace: '',
+  env: new Environment({ skipInstall: true }),
+  'skip-install': true
+})
+// [{ name , default, ... }, ...] => { [name]: default, ... }
+const defaultAnswers = generator.promptQuestions.reduce((acc, curr) => {
+  if (Object.hasOwn(curr, 'default')) {
+    acc[curr.name] = curr.default
+  }
+  return acc
+}, {})
+const testDefaultAnswers = Object.freeze({
+  ...defaultAnswers,
+  // Default values for the sake of the tests.
+  moduleName: 'module-name',
+  description: 'description',
+  mainMaintainer: 'RichardLitt',
+  licensee: 'Richard McRichface',
+  year: false,
+  diffYear: '2018'
+})
+
+describe('standard-readme:app', () => {
   const customTempDir = join(__dirname, './temp')
   const exampleDir = join(__dirname, './examples')
   if (!existsSync(customTempDir)) {
@@ -22,125 +50,443 @@ describe('standard-readme:app', async () => {
       })
     runContext = result
       .create(join(__dirname, './app'))
-      .withAnswers({
-        description: 'test',
-        maintainers: 'RichardLitt',
-        licensee: 'Richard McRichface'
-      })
+      .withAnswers(testDefaultAnswers, { throwOnMissingAnswer: true })
   })
 
-  test('generates default README file with current year', async () => {
+  test('generates default README (given test defaults)', async () => {
     await runContext
       .run()
 
     assert.strictEqual(
       readFileSync(join(customTempDir, 'README.md')).toString(),
       readFileSync(join(exampleDir, 'default-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
     )
   })
 
-  test('generates README with different year', async () => {
-    await runContext
-      .withAnswers({
-        year: false,
-        diffYear: '2016'
-      })
-      .run()
-
-    assert.strictEqual(
-      readFileSync(join(customTempDir, 'README.md')).toString(),
-      readFileSync(join(exampleDir, 'different-year.md')).toString()
-    )
-  })
-
-  test('generates README without different year when present year is confirmed', async () => {
-    await runContext
-      .withAnswers({
-        year: true,
-        diffYear: 2016
-      })
-      .run()
-
-    assert.strictEqual(
-      readFileSync(join(customTempDir, 'README.md')).toString(),
-      readFileSync(join(exampleDir, 'default-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
-    )
-  })
-
-  test('generates README with given license', async () => {
-    await runContext
-      .withAnswers({
-        mit: false,
-        license: 'CC-BY-SA 3.0'
-      })
-      .run()
-
-    assert.strictEqual(
-      readFileSync(join(customTempDir, 'README.md')).toString(),
-      readFileSync(join(exampleDir, 'different-license-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
-    )
-  })
-
-  test('generates README defaulting to MIT license', async () => {
-    await runContext
-      .withAnswers({
-        mit: true,
-        license: 'CC-BY-SA 3.0'
-      })
-      .run()
-
-    assert.strictEqual(
-      readFileSync(join(customTempDir, 'README.md')).toString(),
-      readFileSync(join(exampleDir, 'default-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
-    )
-  })
-
-  test('generates README with suggested full name', async () => {
-    const githubUsername = 'RichardLitt'
+  test('generates maximal README when all options/sections are included', async () => {
     await result
       .create(join(__dirname, './app'))
       .withAnswers({
-        description: 'test',
-        maintainers: githubUsername
-      })
-      .run()
-
-    assert.strictEqual(
-      readFileSync(join(customTempDir, 'README.md')).toString(),
-      readFileSync(join(exampleDir, 'default-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
-        .replace('Richard McRichface', await fullName() ?? githubUsername)
-    )
-  })
-
-  test('generates maximal README', async () => {
-    await runContext
-      .withAnswers({
-        API: true,
-        background: true,
-        badge: true,
-        badges: true,
+        moduleName: 'example',
+        description: 'description',
         banner: true,
         bannerPath: 'test',
-        contributingFile: true,
-        license: 'test',
+        badge: true,
+        badges: true,
         longDescription: true,
-        mit: true,
-        moduleName: 'example',
-        prs: true,
         security: true,
-        year: true
+        background: true,
+        API: true,
+        mainMaintainer: 'RichardLitt',
+        hostedDomain: 'github.com',
+        contributingFile: true,
+        prs: true,
+        mit: true,
+        // license: 'CC BY-SA 4.0',
+        licensee: 'Richard McRichface',
+        year: false,
+        diffYear: '2018'
       })
       .run()
 
     assert.strictEqual(
       readFileSync(join(customTempDir, 'README.md')).toString(),
       readFileSync(join(exampleDir, 'maximal-readme.md')).toString()
-        .replace('2018', new Date().getFullYear())
     )
+  })
+
+  describe('moduleName', () => {
+    const newModuleName = 'foo-module-name'
+
+    test('generates README with fallback value (`generator.appname`) when omitted', async () => {
+      await runContext
+        .withAnswers({
+          moduleName: undefined
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+          .replace(testDefaultAnswers.moduleName, runContext.generator.appname)
+      )
+    })
+
+    test('generates README with provided moduleName', async () => {
+      await runContext
+        .withAnswers({
+          moduleName: newModuleName
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+          .replace(testDefaultAnswers.moduleName, newModuleName)
+      )
+    })
+
+    test('generates README using slugified moduleName', async () => {
+      const moduleNames = [
+        newModuleName.replace('-', ' '),
+        newModuleName.replace('-', '_'),
+        newModuleName.toUpperCase()
+      ]
+      for (const moduleName of moduleNames) {
+        // Need to reset test environment to avoid prompt abort error
+        // on subsequent loops.
+        await helpers.prepareTemporaryDir({
+          cwd: customTempDir
+        })
+        runContext = result
+          .create(join(__dirname, './app'))
+          .withAnswers(testDefaultAnswers)
+
+        await runContext
+          .withAnswers({
+            moduleName
+          })
+          .run()
+
+        assert.strictEqual(
+          readFileSync(join(customTempDir, 'README.md')).toString(),
+          readFileSync(join(exampleDir, 'default-readme.md')).toString()
+            .replace(testDefaultAnswers.moduleName, newModuleName)
+        )
+      }
+    })
+  })
+
+  describe('description', () => {
+    test('fails to generate README when answer is omitted', async () => {
+      const promise = runContext
+        .withAnswers({
+          description: undefined
+        })
+        .run()
+
+      await assert.rejects(promise, {
+        message: 'yeoman-test: question description was asked but answer was not provided'
+      })
+    })
+
+    test('generates README with provided description', async () => {
+      const newDescription = 'foo description'
+
+      await runContext.withAnswers({
+        description: newDescription
+      })
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+          .replace(testDefaultAnswers.description, newDescription)
+      )
+    })
+  })
+
+  describe('banner/bannerPath', () => {
+    test('fails to generate if only banner is true', async () => {
+      const promise = runContext
+        .withAnswers({
+          banner: true
+        })
+        .run()
+
+      await assert.rejects(promise, {
+        message: 'yeoman-test: question bannerPath was asked but answer was not provided'
+      })
+    })
+
+    test('generates default README if only bannerPath is specified', async () => {
+      await runContext
+        .withAnswers({
+          bannerPath: 'test/banner.png'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+      )
+    })
+
+    test('generates README with provided banner', async () => {
+      await runContext
+        .withAnswers({
+          banner: true,
+          bannerPath: 'test/banner.png'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'banner-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('badge/badges', () => {
+    test('generates README without badge', async () => {
+      await runContext
+        .withAnswers({
+          badge: false
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'no-badge-readme.md')).toString()
+      )
+    })
+
+    test('generates README with badges TODO', async () => {
+      await runContext
+        .withAnswers({
+          badges: true
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'badges-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('longDescription', () => {
+    test('generates README without TODO for long description', async () => {
+      await runContext
+        .withAnswers({
+          longDescription: false
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'no-long-description-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('security', () => {
+    test('generates README with security section', async () => {
+      await runContext
+        .withAnswers({
+          security: true
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'security-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('background', () => {
+    test('generates README with background section', async () => {
+      await runContext
+        .withAnswers({
+          background: true
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'background-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('API', () => {
+    test('generates README with API section', async () => {
+      await runContext
+        .withAnswers({
+          API: true
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'api-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('hostedDomain', () => {
+    test('generates README with specified hosted domain', async () => {
+      await runContext
+        .withAnswers({
+          hostedDomain: 'gitlab.com'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md'))
+          .toString()
+          .replace(
+            '[@RichardLitt](https://github.com/RichardLitt)',
+            '[@RichardLitt](https://gitlab.com/RichardLitt)'
+          )
+      )
+    })
+  })
+
+  describe('mainMaintainer', () => {
+    test('generates README when answer is omitted', async () => {
+      await runContext
+        .withAnswers({
+          mainMaintainer: undefined
+        })
+        .run()
+
+      const expectedMaintainer = await defaultAnswers.mainMaintainer()
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md'))
+          .toString()
+          .replace(
+            `[@${testDefaultAnswers.mainMaintainer}](https://github.com/${testDefaultAnswers.mainMaintainer})`,
+            `[@${expectedMaintainer}](https://github.com/${expectedMaintainer})`
+          )
+      )
+    })
+  })
+
+  describe('contributingFile', () => {
+    test('generates README with contributing file', async () => {
+      await runContext
+        .withAnswers({
+          contributingFile: true
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'contributing-file-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('prs', () => {
+    test('generates README when prs is omitted', async () => {
+      await runContext
+        .withAnswers({
+          prs: false
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'prs-readme.md')).toString()
+      )
+    })
+  })
+
+  describe('mit/license/licensee', () => {
+    test('fails to generate README when `mit` is false and no other license is specified', async () => {
+      const promise = runContext
+        .withAnswers({
+          mit: false,
+          license: undefined
+        })
+        .run()
+
+      await assert.rejects(promise, {
+        message: 'yeoman-test: question license was asked but answer was not provided'
+      })
+    })
+
+    test('generates README with license different from MIT', async () => {
+      await runContext
+        .withAnswers({
+          mit: false,
+          license: 'CC BY-SA 4.0'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'different-license-readme.md')).toString()
+      )
+    })
+
+    test('generates README defaulting to MIT license, even when other license specified', async () => {
+      await runContext
+        .withAnswers({
+          mit: true,
+          license: 'CC BY-SA 4.0'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+      )
+    })
+
+    test('generates README with suggested licensee full name', async () => {
+      await runContext
+        .withAnswers({
+          licensee: undefined
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md'))
+          .toString()
+          .replace(
+            'Richard McRichface',
+            (await fullName()) ?? (await testDefaultAnswers.mainMaintainer)
+          )
+      )
+    })
+  })
+
+  describe('year', () => {
+    test('fails to generate README when present year not used and diff year not specified', async () => {
+      const promise = runContext
+        .withAnswers({
+          year: false,
+          diffYear: undefined
+        })
+        .run()
+
+      await assert.rejects(promise, {
+        message: 'yeoman-test: question diffYear was asked but answer was not provided'
+      })
+    })
+
+    test('generates README with provided year', async () => {
+      await runContext
+        .withAnswers({
+          year: false,
+          diffYear: '2016'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'different-year.md')).toString()
+      )
+    })
+
+    test('generates README without different year when present year is confirmed', async () => {
+      await runContext
+        .withAnswers({
+          year: true,
+          diffYear: '2016'
+        })
+        .run()
+
+      assert.strictEqual(
+        readFileSync(join(customTempDir, 'README.md')).toString(),
+        readFileSync(join(exampleDir, 'default-readme.md')).toString()
+          .replace('2018', new Date().getFullYear())
+      )
+    })
   })
 })

--- a/test.js
+++ b/test.js
@@ -100,11 +100,12 @@ describe('standard-readme:app', async () => {
   })
 
   test('generates README with suggested full name', async () => {
+    const githubUsername = 'RichardLitt'
     await result
       .create(join(__dirname, './app'))
       .withAnswers({
         description: 'test',
-        maintainers: 'RichardLitt'
+        maintainers: githubUsername
       })
       .run()
 
@@ -112,7 +113,7 @@ describe('standard-readme:app', async () => {
       readFileSync(join(customTempDir, 'README.md')).toString(),
       readFileSync(join(exampleDir, 'default-readme.md')).toString()
         .replace('2018', new Date().getFullYear())
-        .replace('Richard McRichface', await fullName() ?? '')
+        .replace('Richard McRichface', await fullName() ?? githubUsername)
     )
   })
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,19 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['**/*test.js']
+    include: ['**/*test.js'],
+    onConsoleLog (log, type) {
+      // Suppress expected stderr messages for test cases w/ missing answers.
+      if (
+        type === 'stderr' &&
+        /yeoman-test: question \w+ was asked but answer was not provided/.test(
+          log
+        )
+      ) {
+        return false
+      }
+
+      return true
+    }
   }
 })


### PR DESCRIPTION
The added test assumes that the implementation matches the behaviour of
the `fullname` npm package, which is probably a fine amount of coupling
given that it's only a suggestion.

Resolves: #3

