### PR TITLE
Disable unnecessary message about unchanged package.json from yeoman-environment

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,8 +7,15 @@ import { execSync } from 'node:child_process'
 const domainRegex = /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/
 
 export default class StandardReadmeGenerator extends Generator {
-  constructor (...args) {
-    super(...args)
+  /**
+   * @param {string[]} args
+   * @param {import('yeoman-generator').BaseOptions} options
+   * @param {import('yeoman-generator').BaseFeatures?} features
+   */
+  constructor (args, options, features = {}) {
+    // Suppress log about `package.json` being unchanged.
+    features.customInstallTask = true
+    super(args, options, features)
 
     this.props = {}
     /** @type {import('yeoman-generator').PromptQuestions} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9891,9 +9891,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
`yo-environment` v4 prints a console message if a generator doesn't
change the `package.json` file for a project [^1]. e.g.,

```console
$ yo app/index.js --force
...
No change to package.json was detected. No package manager install will be executed.
```

It's superfluous for a generator that only deals with a README. In other
words, I found the new behavior annoying and wanted to minimize the logs
printed 😅.

So, this change disables the message by telling Yeoman that the
generator has a custom install task, and then not providing one. I wish
I could reference docs describing the behaviour, but I mainly got the
intended behaviour through trial & error, as well as sifting through the
code in `yeoman-generator` [^1][^2].

`vite` was also bumped in the `package-lock.json` file to resolve an
`npm audit` warning.

[^1]: https://github.com/yeoman/environment/blob/9ddabe49be9bcb7e1723bd9db379c5e1c7ae7885/src/package-manager.ts#L71
[^2]: https://github.com/yeoman/environment/blob/9ddabe49be9bcb7e1723bd9db379c5e1c7ae7885/src/environment-base.ts#L796