### PR TITLE
Fix outdated badge

### DIFF
--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -2,7 +2,7 @@
 <% if (banner) { %>
 ![banner](<%= bannerPath %>)
 <% } %><% if (badge) { %>
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)<% } %><% if (badges) { %>
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)<% } %><% if (badges) { %>
 TODO: Put more badges here.<% } %>
 
 <%= description %>


### PR DESCRIPTION
This PR fixes the badge that the generator is using.

Old one : https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square
New one : https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square

It seems the badge style has been changed years ago via this PR : https://github.com/RichardLitt/standard-readme/pull/45 and discussed in this issue: https://github.com/RichardLitt/standard-readme/issues/44

But the generator wasn't updated accordingly.

Fix this issue : https://github.com/RichardLitt/generator-standard-readme/issues/55